### PR TITLE
Fix precedence from Urls props and Opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,13 @@ exports.request = function request (url, opts, onresponse) {
   if (typeof url === 'string') url = new URL(url)
 
   if (URL.isURL(url)) {
-    opts = opts ? { ...opts } : {}
+    const urlProps = {
+      host: url.hostname,
+      path: url.pathname,
+      port: url.port ? parseInt(url.port, 10) : defaultPort(url)
+    }
 
-    opts.host = url.hostname
-    opts.path = url.pathname
-    opts.port = url.port ? parseInt(url.port, 10) : defaultPort(url)
+    opts = { ...urlProps, ...(opts || {}) }
   } else {
     opts = url
   }


### PR DESCRIPTION
Motivated by: https://nodejs.org/api/http.html#httprequesturl-options-callback
```
If both url and options are specified, the objects are merged, with the options properties taking precedence.
```

First discussed at: https://github.com/holepunchto/bare-http1/pull/9#issuecomment-2108404698