### PR TITLE
Timeout

### DIFF
--- a/lib/client-connection.js
+++ b/lib/client-connection.js
@@ -27,6 +27,7 @@ module.exports = class HTTPClientConnection {
     this._onend = this._onend.bind(this)
     this._ondata = this._ondata.bind(this)
     this._ondrain = this._ondrain.bind(this)
+    this._ontimeout = this._ontimeout.bind(this)
 
     socket
       .on('error', this._onerror)
@@ -34,6 +35,15 @@ module.exports = class HTTPClientConnection {
       .on('end', this._onend)
       .on('data', this._ondata)
       .on('drain', this._ondrain)
+  }
+
+  setTimeout (ms, ontimeout) {
+    this.socket.once('timeout', this._ontimeout)
+    if (ontimeout) this.req.once('timeout', ontimeout)
+
+    this.socket.setTimeout(ms)
+
+    return this
   }
 
   _onerror (err) {
@@ -185,6 +195,7 @@ module.exports = class HTTPClientConnection {
       .off('end', this._onend)
       .off('data', this._ondata)
       .off('drain', this._ondrain)
+      .off('timeout', this._ontimeout)
 
     const req = this.req
 
@@ -194,6 +205,10 @@ module.exports = class HTTPClientConnection {
     if (req.emit('upgrade', this.res, this.socket, head || empty)) return
 
     this.socket.destroy()
+  }
+
+  _ontimeout () {
+    this.req.emit('timeout')
   }
 
   _onfinished () {

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -37,6 +37,12 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     if (onresponse) this.once('response', onresponse)
   }
 
+  setTimeout (ms, ontimeout) {
+    this._connection.setTimeout(ms, ontimeout)
+
+    return this
+  }
+
   _header () {
     let h = `${this.method} ${this.path} HTTP/1.1\r\n`
 

--- a/lib/incoming-message.js
+++ b/lib/incoming-message.js
@@ -34,10 +34,10 @@ module.exports = class HTTPIncomingMessage extends Readable {
   }
 
   setTimeout (ms, ontimeout) {
-    this.socket.setTimeout(ms)
-
     this.socket.once('timeout', () => this.emit('timeout'))
     if (ontimeout) this.once('timeout', ontimeout)
+
+    this.socket.setTimeout(ms)
 
     return this
   }

--- a/lib/incoming-message.js
+++ b/lib/incoming-message.js
@@ -33,6 +33,15 @@ module.exports = class HTTPIncomingMessage extends Readable {
     return name.toLowerCase() in this.headers
   }
 
+  setTimeout (ms, ontimeout) {
+    this.socket.setTimeout(ms)
+
+    this.socket.once('timeout', () => this.emit('timeout'))
+    if (ontimeout) this.once('timeout', ontimeout)
+
+    return this
+  }
+
   _predestroy () {
     if (this.upgrade === false && this.socket !== null) this.socket.destroy()
   }

--- a/lib/outgoing-message.js
+++ b/lib/outgoing-message.js
@@ -34,6 +34,15 @@ module.exports = class HTTPOutgoingMessage extends Writable {
     this.headersSent = true
   }
 
+  setTimeout (ms, ontimeout) {
+    this.socket.setTimeout(ms)
+
+    this.socket.once('timeout', () => this.emit('timeout'))
+    if (ontimeout) this.once('timeout', ontimeout)
+
+    return this
+  }
+
   _header () {
     throw errors.NOT_IMPLEMENTED()
   }

--- a/lib/outgoing-message.js
+++ b/lib/outgoing-message.js
@@ -35,10 +35,10 @@ module.exports = class HTTPOutgoingMessage extends Writable {
   }
 
   setTimeout (ms, ontimeout) {
-    this.socket.setTimeout(ms)
-
     this.socket.once('timeout', () => this.emit('timeout'))
     if (ontimeout) this.once('timeout', ontimeout)
+
+    this.socket.setTimeout(ms)
 
     return this
   }

--- a/lib/server-connection.js
+++ b/lib/server-connection.js
@@ -30,10 +30,10 @@ module.exports = class HTTPServerConnection {
     this._ondrain = this._ondrain.bind(this)
     this._ontimeout = this._ontimeout.bind(this)
 
-    if (opts.timeout) {
+    if (this.server.timeout) {
       socket.once('timeout', this._ontimeout)
 
-      socket.setTimeout(opts.timeout)
+      socket.setTimeout(this.server.timeout)
     }
 
     socket

--- a/lib/server-connection.js
+++ b/lib/server-connection.js
@@ -28,6 +28,13 @@ module.exports = class HTTPServerConnection {
     this._onerror = this._onerror.bind(this)
     this._ondata = this._ondata.bind(this)
     this._ondrain = this._ondrain.bind(this)
+    this._ontimeout = this._ontimeout.bind(this)
+
+    if (opts.timeout) {
+      socket.once('timeout', this._ontimeout)
+
+      socket.setTimeout(opts.timeout)
+    }
 
     socket
       .on('error', this._onerror)
@@ -176,6 +183,7 @@ module.exports = class HTTPServerConnection {
       .off('error', this._onerror)
       .off('data', this._ondata)
       .off('drain', this._ondrain)
+      .off('timeout', this._ontimeout)
 
     const req = this.req
 
@@ -183,6 +191,14 @@ module.exports = class HTTPServerConnection {
     req.destroy()
 
     this.server.emit('upgrade', req, this.socket, head || empty)
+  }
+
+  _ontimeout () {
+    const reqTimeout = this.req && this.req.emit('timeout')
+    const resTimeout = this.res && this.res.emit('timeout')
+    const serverTimeout = this.server.emit('timeout', this.socket)
+
+    if (!reqTimeout && !resTimeout && !serverTimeout) this.socket.destroy()
   }
 
   _onfinished () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,12 +13,10 @@ module.exports = class HTTPServer extends TCPServer {
     this._timeout = 0
 
     this.on('connection', (socket) => {
-      const conn = new HTTPServerConnection(this, socket, opts)
+      const optsClone = JSON.parse(JSON.stringify(opts))
+      if (this._timeout) optsClone.timeout = this._timeout
 
-      if (this._timeout) {
-        socket.setTimeout(this._timeout)
-        socket.once('timeout', () => this._ontimeout(conn))
-      }
+      return new HTTPServerConnection(this, socket, optsClone)
     })
 
     if (onrequest) this.on('request', onrequest)
@@ -30,16 +28,9 @@ module.exports = class HTTPServer extends TCPServer {
 
   setTimeout (ms = 0, ontimeout) {
     if (ontimeout) this.on('timeout', ontimeout)
+
     this._timeout = ms
 
     return this
-  }
-
-  _ontimeout (conn) {
-    const reqTimeout = conn.req && conn.req.emit('timeout')
-    const resTimeout = conn.res && conn.res.emit('timeout')
-    const serverTimeout = this.emit('timeout', conn.socket)
-
-    if (!reqTimeout && !resTimeout && !serverTimeout) conn.socket.destroy()
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,8 +10,28 @@ module.exports = class HTTPServer extends TCPServer {
 
     super({ allowHalfOpen: false })
 
-    this.on('connection', (socket) => new HTTPServerConnection(this, socket, opts))
+    this._timeout = 0
+
+    this.on('connection', (socket) => {
+      new HTTPServerConnection(this, socket, opts)
+
+      if (this._timeout) {
+        socket.setTimeout(this._timeout)
+        socket.once('timeout', () => this.emit('timeout', socket))
+      }
+    })
 
     if (onrequest) this.on('request', onrequest)
+  }
+
+  get timeout () {
+    return this._timeout || undefined // For Node.js compatibility
+  }
+
+  setTimeout (ms = 0, ontimeout) {
+    if (ontimeout) this.on('timeout', ontimeout)
+    this._timeout = ms
+
+    return this
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,12 +12,7 @@ module.exports = class HTTPServer extends TCPServer {
 
     this._timeout = 0
 
-    this.on('connection', (socket) => {
-      const optsClone = JSON.parse(JSON.stringify(opts))
-      if (this._timeout) optsClone.timeout = this._timeout
-
-      return new HTTPServerConnection(this, socket, optsClone)
-    })
+    this.on('connection', (socket) => new HTTPServerConnection(this, socket, opts))
 
     if (onrequest) this.on('request', onrequest)
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,11 +13,11 @@ module.exports = class HTTPServer extends TCPServer {
     this._timeout = 0
 
     this.on('connection', (socket) => {
-      new HTTPServerConnection(this, socket, opts)
+      const conn = new HTTPServerConnection(this, socket, opts)
 
       if (this._timeout) {
         socket.setTimeout(this._timeout)
-        socket.once('timeout', () => this.emit('timeout', socket))
+        socket.once('timeout', () => this._ontimeout(conn))
       }
     })
 
@@ -33,5 +33,13 @@ module.exports = class HTTPServer extends TCPServer {
     this._timeout = ms
 
     return this
+  }
+
+  _ontimeout (conn) {
+    const reqTimeout = conn.req && conn.req.emit('timeout')
+    const resTimeout = conn.res && conn.res.emit('timeout')
+    const serverTimeout = this.emit('timeout', conn.socket)
+
+    if (!reqTimeout && !resTimeout && !serverTimeout) conn.socket.destroy()
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "bare-events": "^2.0.0",
     "bare-stream": "^2.0.0",
-    "bare-tcp": "^1.1.2"
+    "bare-tcp": "^1.8.0"
   },
   "devDependencies": {
     "brittle": "^3.3.0",

--- a/test.js
+++ b/test.js
@@ -565,6 +565,40 @@ test('server timeout', async function (t) {
   server.close()
 })
 
+test('close the server at timeout if do not have any handler', async function (t) {
+  t.plan(1)
+  const server = http.createServer().listen(0).setTimeout(100)
+
+  await waitForServer(server)
+
+  const client = http.request({ port: server.address().port })
+
+  client.on('error', () => {
+    t.pass()
+
+    server.close()
+  })
+})
+
+test('do not close the server at timeout if a handler is found', async function (t) {
+  t.plan(1)
+
+  const server = http.createServer((req, res) => {
+    res.on('timeout', () => {
+      t.pass('response timeout')
+
+      res.end()
+      server.close()
+    })
+  })
+
+  server.listen(0).setTimeout(100)
+
+  await waitForServer(server)
+
+  http.request({ port: server.address().port }).end()
+})
+
 test('server response timeout', async function (t) {
   const sub = t.test()
   sub.plan(2)


### PR DESCRIPTION
Added `setTimeouts` and `timeout` events for all: ClientRequest, Server, ServerResponse, IncomingMessage and Outgoing Message. Also the `server.timeout` prop.

Maybe I went too far at this PR, no problem at cutting extra pieces. The only 'timeout's not included are `headersTimeout`, `requestTimeout` and `keepAliveTimeout`.

---

The second commit (https://github.com/holepunchto/bare-http1/pull/14/commits/a72ef614caba540ad82cfd38b794713247657b10) adds the behavior:

> If no 'timeout' listener is added to the request, the response, or the server, then sockets are destroyed when they time out. If a handler is assigned to the request, the response, or the server's 'timeout' events, timed out sockets must be handled explicitly.

Copycat from: https://github.com/nodejs/node/blob/6671f7ef6fa923a254fc1c48a84c7a9203420c32/lib/_http_server.js#L786

If this behavior isn't interesting for us, we can easily revert the commit.