### PR TITLE
Add agent socket reuse

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -63,7 +63,6 @@ module.exports = class HTTPAgent {
 
       socket.on('free', () => this._onfree(socket, name))
       socket.on('close', () => this._onremove(socket, name))
-      socket.on('end', () => socket.destroy())
     }
 
     let sockets = this._sockets.get(name)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -52,8 +52,10 @@ module.exports = class HTTPAgent {
     let socket
 
     if (this._freeSockets.has(name)) {
-      socket = this._freeSockets.get(name).shift()
-      if (this._freeSockets.get(name).length === 0) this._freeSockets.delete(name)
+      const sockets = this._freeSockets.get(name)
+      socket = sockets.values().next().value
+      sockets.delete(socket)
+      if (sockets.size === 0) this._freeSockets.delete(name)
 
       this.reuseSocket(socket, req)
     } else {
@@ -63,46 +65,50 @@ module.exports = class HTTPAgent {
       socket.on('close', () => this._onremove(socket, name))
     }
 
-    if (!this._sockets.has(name)) this._sockets.set(name, new Set())
+    let sockets = this._sockets.get(name)
+    if (sockets === undefined) {
+      sockets = new Set()
+      this._sockets.set(name, sockets)
+    }
 
-    this._sockets.get(name).add(socket)
+    sockets.add(socket)
 
-    req._onSocket(socket, opts)
+    req._onsocket(socket, opts)
   }
 
   destroy () {
-    const sets = [this._sockets, this._freeSockets]
-
-    sets.forEach((set) => {
-      set.forEach((sockets) => {
-        sockets.forEach((socket) => socket.destroy())
-      })
-    })
+    for (const set of [this._sockets, this._freeSockets]) {
+      for (const [, sockets] of set) {
+        for (const socket of sockets) socket.destroy()
+      }
+    }
   }
 
   _onfree (socket, name) {
     if (this.keepSocketAlive(socket)) {
       this._onremove(socket, name, false) // remove from agent._sockets
 
-      if (!this._freeSockets.has(name)) this._freeSockets.set(name, [])
-      this._freeSockets.get(name).push(socket)
+      let sockets = this._freeSockets.get(name)
+      if (sockets === undefined) {
+        sockets = new Set()
+        this._freeSockets.set(name, sockets)
+      }
+
+      sockets.add(socket)
     } else {
       socket.end()
     }
   }
 
   _onremove (socket, name, all = true) {
-    if (this._sockets.has(name)) {
-      this._sockets.get(name).delete(socket)
+    const sets = all ? [this._sockets, this._freeSockets] : [this._sockets]
 
-      if (this._sockets.get(name).size === 0) this._sockets.delete(name)
-    }
+    for (const set of sets) {
+      const sockets = set.get(name)
+      if (sockets === undefined) continue
 
-    if (all && this._freeSockets.has(name)) {
-      const index = this._freeSockets.get(name).indexOf(socket)
-      if (index !== -1) this._freeSockets.get(name).splice(index, 1)
-
-      if (this._freeSockets.get(name).length === 0) this._freeSockets.delete(name)
+      sockets.delete(socket)
+      if (sockets.size === 0) set.delete(name)
     }
   }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -11,8 +11,8 @@ module.exports = class HTTPAgent {
       timeout = -1
     } = opts
 
-    this._sockets = {}
-    this._freeSockets = {}
+    this._sockets = new Map()
+    this._freeSockets = new Map()
 
     this._keepAlive = typeof keepAlive === 'number' ? keepAlive : keepAlive ? keepAliveMsecs : -1
 
@@ -51,9 +51,9 @@ module.exports = class HTTPAgent {
 
     let socket
 
-    if (this._freeSockets[name]) {
-      socket = this._freeSockets[name].shift()
-      if (this._freeSockets[name].length === 0) delete this._freeSockets[name]
+    if (this._freeSockets.has(name)) {
+      socket = this._freeSockets.get(name).shift()
+      if (this._freeSockets.get(name).length === 0) this._freeSockets.delete(name)
 
       this.reuseSocket(socket) // TODO: missing `req` parameter
     } else {
@@ -63,8 +63,9 @@ module.exports = class HTTPAgent {
       socket.on('close', () => this._onremove(socket, name))
     }
 
-    if (!this._sockets[name]) this._sockets[name] = []
-    this._sockets[name].push(socket)
+    if (!this._sockets.has(name)) this._sockets.set(name, new Set())
+
+    this._sockets.get(name).add(socket)
 
     return socket
   }
@@ -73,10 +74,7 @@ module.exports = class HTTPAgent {
     const sets = [this._sockets, this._freeSockets]
 
     sets.forEach((set) => {
-      const keys = Object.keys(set)
-
-      keys.forEach((key) => {
-        const sockets = set[key]
+      set.forEach((sockets) => {
         sockets.forEach((socket) => socket.destroy())
       })
     })
@@ -86,25 +84,26 @@ module.exports = class HTTPAgent {
     if (this.keepSocketAlive(socket)) {
       this._onremove(socket, name, false) // remove from agent._sockets
 
-      if (!this._freeSockets[name]) this._freeSockets[name] = []
-      this._freeSockets[name].push(socket)
+      if (!this._freeSockets.has(name)) this._freeSockets.set(name, [])
+      this._freeSockets.get(name).push(socket)
     } else {
       socket.end()
     }
   }
 
   _onremove (socket, name, all = true) {
-    const sets = all ? [this._sockets, this._freeSockets] : [this._sockets]
+    if (this._sockets.has(name)) {
+      this._sockets.get(name).delete(socket)
 
-    sets.forEach((sockets) => {
-      if (sockets[name]) {
-        const index = sockets[name].indexOf(socket)
-        if (index !== -1) {
-          sockets[name].splice(index, 1)
-          if (sockets[name].length === 0) delete sockets[name]
-        }
-      }
-    })
+      if (this._sockets.get(name).size === 0) this._sockets.delete(name)
+    }
+
+    if (all && this._freeSockets.has(name)) {
+      const index = this._freeSockets.get(name).indexOf(socket)
+      if (index !== -1) this._freeSockets.get(name).splice(index, 1)
+
+      if (this._freeSockets.get(name).length === 0) this._freeSockets.delete(name)
+    }
   }
 
   static global = new this({ keepAlive: 1000, timeout: 5000 })

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -63,6 +63,7 @@ module.exports = class HTTPAgent {
 
       socket.on('free', () => this._onfree(socket, name))
       socket.on('close', () => this._onremove(socket, name))
+      socket.on('end', () => socket.destroy())
     }
 
     let sockets = this._sockets.get(name)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,4 +1,5 @@
 const tcp = require('bare-tcp')
+const HTTPClientConnection = require('./client-connection')
 
 module.exports = class HTTPAgent {
   constructor (opts = {}) {
@@ -61,8 +62,9 @@ module.exports = class HTTPAgent {
     } else {
       socket = this.createConnection(opts)
 
-      socket.on('free', () => this._onfree(socket, name))
-      socket.on('close', () => this._onremove(socket, name))
+      socket
+        .on('free', () => this._onfree(socket, name))
+        .on('close', () => this._onremove(socket, name))
     }
 
     let sockets = this._sockets.get(name)
@@ -73,7 +75,11 @@ module.exports = class HTTPAgent {
 
     sockets.add(socket)
 
-    req._onsocket(socket, opts)
+    req.socket = socket
+
+    const connection = HTTPClientConnection.from(socket, opts)
+
+    connection.req = req
   }
 
   destroy () {
@@ -86,7 +92,7 @@ module.exports = class HTTPAgent {
 
   _onfree (socket, name) {
     if (this.keepSocketAlive(socket)) {
-      this._onremove(socket, name, false) // remove from agent._sockets
+      this._onremove(socket, name, false)
 
       let sockets = this._freeSockets.get(name)
       if (sockets === undefined) {
@@ -101,9 +107,7 @@ module.exports = class HTTPAgent {
   }
 
   _onremove (socket, name, all = true) {
-    const sets = all ? [this._sockets, this._freeSockets] : [this._sockets]
-
-    for (const set of sets) {
+    for (const set of all ? [this._sockets, this._freeSockets] : [this._sockets]) {
       const sockets = set.get(name)
       if (sockets === undefined) continue
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -11,7 +11,12 @@ module.exports = class HTTPAgent {
       timeout = -1
     } = opts
 
+    this._sockets = {}
+    this._freeSockets = {}
+
     this._keepAlive = typeof keepAlive === 'number' ? keepAlive : keepAlive ? keepAliveMsecs : -1
+
+    this._opts = opts
     this._maxSockets = maxSockets
     this._maxTotalSockets = maxTotalSockets
     this._maxFreeSockets = maxFreeSockets
@@ -27,7 +32,79 @@ module.exports = class HTTPAgent {
   }
 
   keepSocketAlive (socket) {
-    return false
+    if (this._keepAlive === -1) return false
+
+    socket.setKeepAlive(true, this._keepAlive)
+    socket.unref()
+
+    return true
+  }
+
+  getName (opts) {
+    return `${opts.host}:${opts.port}`
+  }
+
+  getSocket (opts) {
+    opts = { ...opts, ...this._opts }
+
+    const name = this.getName(opts)
+
+    let socket
+
+    if (this._freeSockets[name]) {
+      socket = this._freeSockets[name].shift()
+      if (this._freeSockets[name].length === 0) delete this._freeSockets[name]
+
+      this.reuseSocket(socket) // TODO: missing `req` parameter
+    } else {
+      socket = this.createConnection(opts)
+
+      socket.on('free', () => this._onfree(socket, name))
+      socket.on('close', () => this._onremove(socket, name))
+    }
+
+    if (!this._sockets[name]) this._sockets[name] = []
+    this._sockets[name].push(socket)
+
+    return socket
+  }
+
+  destroy () {
+    const sets = [this._sockets, this._freeSockets]
+
+    sets.forEach((set) => {
+      const keys = Object.keys(set)
+
+      keys.forEach((key) => {
+        const sockets = set[key]
+        sockets.forEach((socket) => socket.destroy())
+      })
+    })
+  }
+
+  _onfree (socket, name) {
+    if (this.keepSocketAlive(socket)) {
+      this._onremove(socket, name, false) // remove from agent._sockets
+
+      if (!this._freeSockets[name]) this._freeSockets[name] = []
+      this._freeSockets[name].push(socket)
+    } else {
+      socket.end()
+    }
+  }
+
+  _onremove (socket, name, all = true) {
+    const sets = all ? [this._sockets, this._freeSockets] : [this._sockets]
+
+    sets.forEach((sockets) => {
+      if (sockets[name]) {
+        const index = sockets[name].indexOf(socket)
+        if (index !== -1) {
+          sockets[name].splice(index, 1)
+          if (sockets[name].length === 0) delete sockets[name]
+        }
+      }
+    })
   }
 
   static global = new this({ keepAlive: 1000, timeout: 5000 })

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -16,7 +16,7 @@ module.exports = class HTTPAgent {
 
     this._keepAlive = typeof keepAlive === 'number' ? keepAlive : keepAlive ? keepAliveMsecs : -1
 
-    this._opts = opts
+    this._opts = { ...opts }
     this._maxSockets = maxSockets
     this._maxTotalSockets = maxTotalSockets
     this._maxFreeSockets = maxFreeSockets
@@ -44,7 +44,7 @@ module.exports = class HTTPAgent {
     return `${opts.host}:${opts.port}`
   }
 
-  getSocket (opts) {
+  addRequest (req, opts) {
     opts = { ...opts, ...this._opts }
 
     const name = this.getName(opts)
@@ -55,7 +55,7 @@ module.exports = class HTTPAgent {
       socket = this._freeSockets.get(name).shift()
       if (this._freeSockets.get(name).length === 0) this._freeSockets.delete(name)
 
-      this.reuseSocket(socket) // TODO: missing `req` parameter
+      this.reuseSocket(socket, req)
     } else {
       socket = this.createConnection(opts)
 
@@ -67,7 +67,7 @@ module.exports = class HTTPAgent {
 
     this._sockets.get(name).add(socket)
 
-    return socket
+    req._onSocket(socket, opts)
   }
 
   destroy () {

--- a/lib/client-connection.js
+++ b/lib/client-connection.js
@@ -5,6 +5,16 @@ const errors = require('./errors')
 const empty = Buffer.alloc(0)
 
 module.exports = class HTTPClientConnection {
+  static _connections = new WeakMap()
+
+  static for (socket) {
+    return this._connections.get(socket) || null
+  }
+
+  static from (socket, opts) {
+    return this.for(socket) || new this(socket, opts)
+  }
+
   constructor (socket, opts = {}) {
     const {
       IncomingMessage = HTTPIncomingMessage
@@ -21,6 +31,7 @@ module.exports = class HTTPClientConnection {
     this._length = -1
     this._read = 0
     this._buffer = null
+    this._idle = true
 
     this._onerror = this._onerror.bind(this)
     this._onclose = this._onclose.bind(this)
@@ -36,6 +47,12 @@ module.exports = class HTTPClientConnection {
       .on('data', this._ondata)
       .on('drain', this._ondrain)
       .on('timeout', this._ontimeout)
+
+    HTTPClientConnection._connections.set(socket, this)
+  }
+
+  get idle () {
+    return this._idle
   }
 
   _onerror (err) {
@@ -51,6 +68,8 @@ module.exports = class HTTPClientConnection {
   }
 
   _ondata (data) {
+    this._idle = false
+
     if (this._state === constants.state.IN_BODY) return this._onbody(data)
 
     if (this._buffer !== null) {
@@ -127,7 +146,6 @@ module.exports = class HTTPClientConnection {
     }
 
     this.req.on('close', () => {
-      this._removeSocketListeners()
       this.req = null
     })
 
@@ -187,7 +205,7 @@ module.exports = class HTTPClientConnection {
   }
 
   _onupgrade (head) {
-    this._removeSocketListeners()
+    this._ondetach()
 
     const req = this.req
 
@@ -206,8 +224,6 @@ module.exports = class HTTPClientConnection {
   _onfinished () {
     if (this.res) this.res.push(null)
     if (this.req) this.req._continueFinal()
-
-    this.socket.emit('free')
   }
 
   _onreset () {
@@ -215,13 +231,16 @@ module.exports = class HTTPClientConnection {
     this._length = -1
     this._read = 0
     this._buffer = null
+    this._idle = true
+
+    this.socket.emit('free')
   }
 
   _ondrain () {
     if (this.req) this.req._continueWrite()
   }
 
-  _removeSocketListeners () {
+  _ondetach () {
     this.socket
       .off('error', this._onerror)
       .off('close', this._onclose)
@@ -229,5 +248,7 @@ module.exports = class HTTPClientConnection {
       .off('data', this._ondata)
       .off('drain', this._ondrain)
       .off('timeout', this._ontimeout)
+
+    HTTPClientConnection._connections.delete(this.socket)
   }
 }

--- a/lib/client-connection.js
+++ b/lib/client-connection.js
@@ -126,11 +126,17 @@ module.exports = class HTTPClientConnection {
       headers[name.toLowerCase()] = value
     }
 
-    this.req.on('close', () => { this.req = null })
+    this.req.on('close', () => {
+      this._removeSocketListeners()
+      this.req = null
+    })
 
     this.res = new this._IncomingMessage(this.socket, headers, { statusCode: parseInt(statusCode, 10), statusMessage: statusMessage.join(' ') })
 
-    this.res.on('close', () => { this.res = null; this._onreset() })
+    this.res.on('close', () => {
+      this.res = null
+      this._onreset()
+    })
 
     if (headers.connection && headers.connection.toLowerCase() === 'upgrade') {
       const head = this._buffer
@@ -181,13 +187,7 @@ module.exports = class HTTPClientConnection {
   }
 
   _onupgrade (head) {
-    this.socket
-      .off('error', this._onerror)
-      .off('close', this._onclose)
-      .off('end', this._onend)
-      .off('data', this._ondata)
-      .off('drain', this._ondrain)
-      .off('timeout', this._ontimeout)
+    this._removeSocketListeners()
 
     const req = this.req
 
@@ -207,7 +207,7 @@ module.exports = class HTTPClientConnection {
     if (this.res) this.res.push(null)
     if (this.req) this.req._continueFinal()
 
-    this.socket.end()
+    this.socket.emit('free')
   }
 
   _onreset () {
@@ -219,5 +219,15 @@ module.exports = class HTTPClientConnection {
 
   _ondrain () {
     if (this.req) this.req._continueWrite()
+  }
+
+  _removeSocketListeners () {
+    this.socket
+      .off('error', this._onerror)
+      .off('close', this._onclose)
+      .off('end', this._onend)
+      .off('data', this._ondata)
+      .off('drain', this._ondrain)
+      .off('timeout', this._ontimeout)
   }
 }

--- a/lib/client-connection.js
+++ b/lib/client-connection.js
@@ -145,16 +145,11 @@ module.exports = class HTTPClientConnection {
       headers[name.toLowerCase()] = value
     }
 
-    this.req.on('close', () => {
-      this.req = null
-    })
+    this.req.on('close', () => { this.req = null })
 
     this.res = new this._IncomingMessage(this.socket, headers, { statusCode: parseInt(statusCode, 10), statusMessage: statusMessage.join(' ') })
 
-    this.res.on('close', () => {
-      this.res = null
-      this._onreset()
-    })
+    this.res.on('close', () => { this.res = null; this._onreset() })
 
     if (headers.connection && headers.connection.toLowerCase() === 'upgrade') {
       const head = this._buffer

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -25,6 +25,8 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     this.path = path
     this.headers = { host: host + ':' + port, ...opts.headers }
 
+    this._connection = null
+
     this._chunked = method !== 'GET' && method !== 'HEAD'
 
     this._pendingFinal = null

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -25,8 +25,6 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     this.path = path
     this.headers = { host: host + ':' + port, ...opts.headers }
 
-    this._connection = null
-
     this._chunked = method !== 'GET' && method !== 'HEAD'
 
     this._pendingFinal = null
@@ -99,14 +97,6 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     const cb = this._pendingFinal
     this._pendingFinal = null
     cb(null)
-  }
-
-  _onsocket (socket, opts) {
-    this.socket = socket
-
-    const { connection = new HTTPClientConnection(socket, opts) } = opts
-    connection.req = this
-    this._connection = connection
   }
 }
 

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -18,7 +18,7 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     const port = opts.port = opts.port || 80
 
     const {
-      connection = new HTTPClientConnection(agent.createConnection(opts), opts)
+      connection = new HTTPClientConnection(agent.getSocket(opts), opts)
     } = opts
 
     super(connection.socket)

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -1,6 +1,5 @@
 const HTTPAgent = require('./agent')
 const HTTPOutgoingMessage = require('./outgoing-message')
-const HTTPClientConnection = require('./client-connection')
 
 module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
   constructor (opts = {}, onresponse = null) {

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -99,7 +99,7 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     cb(null)
   }
 
-  _onSocket (socket, opts) {
+  _onsocket (socket, opts) {
     this.socket = socket
 
     const { connection = new HTTPClientConnection(socket, opts) } = opts

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -17,19 +17,14 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     const host = opts.host = opts.host || 'localhost'
     const port = opts.port = opts.port || 80
 
-    const {
-      connection = new HTTPClientConnection(agent.getSocket(opts), opts)
-    } = opts
+    super()
 
-    super(connection.socket)
-
-    connection.req = this
+    agent.addRequest(this, opts)
 
     this.method = method
     this.path = path
     this.headers = { host: host + ':' + port, ...opts.headers }
 
-    this._connection = connection
     this._chunked = method !== 'GET' && method !== 'HEAD'
 
     this._pendingFinal = null
@@ -102,6 +97,14 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
     const cb = this._pendingFinal
     this._pendingFinal = null
     cb(null)
+  }
+
+  _onSocket (socket, opts) {
+    this.socket = socket
+
+    const { connection = new HTTPClientConnection(socket, opts) } = opts
+    connection.req = this
+    this._connection = connection
   }
 }
 

--- a/lib/server-connection.js
+++ b/lib/server-connection.js
@@ -1,3 +1,4 @@
+const tcp = require('bare-tcp')
 const HTTPIncomingMessage = require('./incoming-message')
 const HTTPServerResponse = require('./server-response')
 const constants = require('./constants')
@@ -5,6 +6,12 @@ const constants = require('./constants')
 const empty = Buffer.alloc(0)
 
 module.exports = class HTTPServerConnection {
+  static _connections = new WeakMap()
+
+  static for (socket) {
+    return this._connections.get(socket) || null
+  }
+
   constructor (server, socket, opts = {}) {
     const {
       IncomingMessage = HTTPIncomingMessage,
@@ -24,6 +31,7 @@ module.exports = class HTTPServerConnection {
     this._length = -1
     this._read = 0
     this._buffer = null
+    this._idle = true
 
     this._onerror = this._onerror.bind(this)
     this._ondata = this._ondata.bind(this)
@@ -36,7 +44,13 @@ module.exports = class HTTPServerConnection {
       .on('drain', this._ondrain)
       .on('timeout', this._ontimeout)
 
+    HTTPServerConnection._connections.set(socket, this)
+
     if (this.server.timeout) socket.setTimeout(this.server.timeout)
+  }
+
+  get idle () {
+    return this._idle
   }
 
   _onerror (err) {
@@ -44,6 +58,8 @@ module.exports = class HTTPServerConnection {
   }
 
   _ondata (data) {
+    this._idle = false
+
     if (this._state === constants.state.IN_BODY) return this._onbody(data)
 
     if (this._buffer !== null) {
@@ -120,12 +136,8 @@ module.exports = class HTTPServerConnection {
     }
 
     this.req = new this._IncomingMessage(this.socket, headers, { method, url })
-    this.server._requestSockets.add(this.socket)
 
     this.req.on('close', () => {
-      this.server._requestSockets.delete(this.socket)
-      this.server._checkPendingClose(this.socket)
-
       this.req = null
       this._onreset()
     })
@@ -137,12 +149,8 @@ module.exports = class HTTPServerConnection {
     }
 
     this.res = new this._ServerResponse(this.socket, this.req, headers.connection === 'close')
-    this.server._responseSockets.add(this.socket)
 
     this.res.on('close', () => {
-      this.server._responseSockets.delete(this.socket)
-      this.server._checkPendingClose(this.socket)
-
       this.res = null
     })
 
@@ -189,11 +197,7 @@ module.exports = class HTTPServerConnection {
   }
 
   _onupgrade (head) {
-    this.socket
-      .off('error', this._onerror)
-      .off('data', this._ondata)
-      .off('drain', this._ondrain)
-      .off('timeout', this._ontimeout)
+    this._ondetach()
 
     const req = this.req
 
@@ -220,9 +224,24 @@ module.exports = class HTTPServerConnection {
     this._length = -1
     this._read = 0
     this._buffer = null
+    this._idle = true
+
+    if (this.server._state & tcp.constants.state.CLOSING) {
+      this.socket.destroy()
+    }
   }
 
   _ondrain () {
     if (this.res) this.res._continueWrite()
+  }
+
+  _ondetach () {
+    this.socket
+      .off('error', this._onerror)
+      .off('data', this._ondata)
+      .off('drain', this._ondrain)
+      .off('timeout', this._ontimeout)
+
+    HTTPServerConnection._connections.delete(this.socket)
   }
 }

--- a/lib/server-connection.js
+++ b/lib/server-connection.js
@@ -137,10 +137,7 @@ module.exports = class HTTPServerConnection {
 
     this.req = new this._IncomingMessage(this.socket, headers, { method, url })
 
-    this.req.on('close', () => {
-      this.req = null
-      this._onreset()
-    })
+    this.req.on('close', () => { this.req = null; this._onreset() })
 
     if (headers.connection && headers.connection.toLowerCase() === 'upgrade') {
       const head = this._buffer
@@ -150,9 +147,7 @@ module.exports = class HTTPServerConnection {
 
     this.res = new this._ServerResponse(this.socket, this.req, headers.connection === 'close')
 
-    this.res.on('close', () => {
-      this.res = null
-    })
+    this.res.on('close', () => { this.res = null })
 
     this.server.emit('request', this.req, this.res)
 

--- a/lib/server-connection.js
+++ b/lib/server-connection.js
@@ -120,8 +120,15 @@ module.exports = class HTTPServerConnection {
     }
 
     this.req = new this._IncomingMessage(this.socket, headers, { method, url })
+    this.server._requestSockets.add(this.socket)
 
-    this.req.on('close', () => { this.req = null; this._onreset() })
+    this.req.on('close', () => {
+      this.server._requestSockets.delete(this.socket)
+      this.server._checkPendingClose(this.socket)
+
+      this.req = null
+      this._onreset()
+    })
 
     if (headers.connection && headers.connection.toLowerCase() === 'upgrade') {
       const head = this._buffer
@@ -130,8 +137,14 @@ module.exports = class HTTPServerConnection {
     }
 
     this.res = new this._ServerResponse(this.socket, this.req, headers.connection === 'close')
+    this.server._responseSockets.add(this.socket)
 
-    this.res.on('close', () => { this.res = null })
+    this.res.on('close', () => {
+      this.server._responseSockets.delete(this.socket)
+      this.server._checkPendingClose(this.socket)
+
+      this.res = null
+    })
 
     this.server.emit('request', this.req, this.res)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,8 +31,11 @@ module.exports = class HTTPServer extends TCPServer {
   }
 
   close () {
-    this._closeConnections()
-    if (!this._pendingClose) super.close()
+    this._closeIdleConnections()
+
+    queueMicrotask(() => {
+      this._connections.size === 0 ? super.close() : this._pendingClose = true
+    })
   }
 
   _checkPendingClose (socket) {
@@ -46,9 +49,9 @@ module.exports = class HTTPServer extends TCPServer {
     }
   }
 
-  _closeConnections () {
+  _closeIdleConnections () {
     for (const socket of this._connections) {
-      this._isActive(socket) ? this._pendingClose = true : socket.destroy()
+      if (!this._isActive(socket)) socket.destroy()
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,9 +11,6 @@ module.exports = class HTTPServer extends TCPServer {
     super({ allowHalfOpen: false })
 
     this._timeout = 0
-    this._pendingClose = false
-    this._requestSockets = new Set()
-    this._responseSockets = new Set()
 
     this.on('connection', (socket) => new HTTPServerConnection(this, socket, opts))
 
@@ -30,32 +27,15 @@ module.exports = class HTTPServer extends TCPServer {
     return this
   }
 
-  close () {
-    this._closeIdleConnections()
+  close (onclose) {
+    super.close(onclose)
 
-    queueMicrotask(() => {
-      this._connections.size === 0 ? super.close() : this._pendingClose = true
-    })
-  }
-
-  _checkPendingClose (socket) {
-    if (!this._pendingClose) return
-
-    if (!this._isActive(socket)) socket.end()
-
-    if (this._connections.size === 0) {
-      this._pendingClose = false
-      super.close()
-    }
-  }
-
-  _closeIdleConnections () {
     for (const socket of this._connections) {
-      if (!this._isActive(socket)) socket.destroy()
-    }
-  }
+      const connection = HTTPServerConnection.for(socket)
 
-  _isActive (socket) {
-    return this._requestSockets.has(socket) || this._responseSockets.has(socket)
+      if (connection && connection.idle) {
+        socket.destroy()
+      }
+    }
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,6 +11,9 @@ module.exports = class HTTPServer extends TCPServer {
     super({ allowHalfOpen: false })
 
     this._timeout = 0
+    this._pendingClose = false
+    this._requestSockets = new Set()
+    this._responseSockets = new Set()
 
     this.on('connection', (socket) => new HTTPServerConnection(this, socket, opts))
 
@@ -29,10 +32,27 @@ module.exports = class HTTPServer extends TCPServer {
 
   close () {
     this._closeConnections()
-    super.close()
+    if (!this._pendingClose) super.close()
+  }
+
+  _checkPendingClose (socket) {
+    if (!this._pendingClose) return
+
+    if (!this._isActive(socket)) socket.end()
+
+    if (this._connections.size === 0) {
+      this._pendingClose = false
+      super.close()
+    }
   }
 
   _closeConnections () {
-    for (const socket of this._connections) socket.end()
+    for (const socket of this._connections) {
+      this._isActive(socket) ? this._pendingClose = true : socket.destroy()
+    }
+  }
+
+  _isActive (socket) {
+    return this._requestSockets.has(socket) || this._responseSockets.has(socket)
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,9 @@ module.exports = class HTTPServer extends TCPServer {
 
   setTimeout (ms = 0, ontimeout) {
     if (ontimeout) this.on('timeout', ontimeout)
+
     this._timeout = ms
+
     return this
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,9 +23,16 @@ module.exports = class HTTPServer extends TCPServer {
 
   setTimeout (ms = 0, ontimeout) {
     if (ontimeout) this.on('timeout', ontimeout)
-
     this._timeout = ms
-
     return this
+  }
+
+  close () {
+    this._closeConnections()
+    super.close()
+  }
+
+  _closeConnections () {
+    for (const socket of this._connections) socket.end()
   }
 }

--- a/test.js
+++ b/test.js
@@ -514,7 +514,7 @@ test('custom request headers', async function (t) {
 
   await ht
 
-  server.close()
+  setImmediate(() => server.close())
 })
 
 test('request timeout', async function (t) {

--- a/test.js
+++ b/test.js
@@ -65,8 +65,7 @@ test('basic', async function (t) {
     host: server.address().address,
     port: server.address().port,
     path: '/something/?key1=value1&key2=value2&enabled',
-    headers: { 'Content-Length': 12 },
-    agent: false
+    headers: { 'Content-Length': 12 }
   }, (req) => {
     req.write('body message')
     req.end()
@@ -193,8 +192,7 @@ test('write head', async function (t) {
     method: 'GET',
     host: server.address().address,
     port: server.address().port,
-    path: '/',
-    agent: false
+    path: '/'
   })
 
   t.absent(reply.error)
@@ -232,8 +230,7 @@ test('write head with headers', async function (t) {
     method: 'GET',
     host: server.address().address,
     port: server.address().port,
-    path: '/',
-    agent: false
+    path: '/'
   })
 
   t.absent(reply.error)
@@ -278,8 +275,7 @@ test('chunked', async function (t) {
     method: 'POST',
     host: server.address().address,
     port: server.address().port,
-    path: '/',
-    agent: false
+    path: '/'
   }, (req) => {
     req.write('request body part 1 + ')
     setImmediate(() => { req.end('request body part 2') })
@@ -488,11 +484,11 @@ test('make requests using url', async function (t) {
   const url = `http://localhost:${server.address().port}/path`
   const expectedBuf = Buffer.from('response')
 
-  http.request(url, { agent: false }, res => {
+  http.request(url, res => {
     res.on('data', (data) => rqts.alike(data, expectedBuf, 'url as string'))
   }).end()
 
-  http.request(new URL(url), { agent: false }, res => {
+  http.request(new URL(url), res => {
     res.on('data', (data) => rqts.alike(data, expectedBuf, 'url instance'))
   }).end()
 
@@ -514,7 +510,7 @@ test('custom request headers', async function (t) {
   })
 
   const { port } = server.address()
-  http.request({ port, headers: { 'custom-header': 'value' }, agent: false }).end()
+  http.request({ port, headers: { 'custom-header': 'value' } }).end()
 
   await ht
 
@@ -532,7 +528,7 @@ test('request timeout', async function (t) {
 
   await waitForServer(server)
 
-  const client = http.request({ port: server.address().port, agent: false }).end()
+  const client = http.request({ port: server.address().port }).end()
 
   client.setTimeout(100, () => sub.pass('callback'))
   client.on('timeout', () => sub.pass('event'))
@@ -562,12 +558,12 @@ test('server timeout', async function (t) {
   await waitForServer(server)
 
   const { port } = server.address()
-  const req = http.request({ port, agent: false })
+  const req = http.request({ port })
 
   await sub
 
   req.end()
-  server.close()
+  setImmediate(() => server.close())
 })
 
 test('close the server at timeout if do not have any handler', async function (t) {
@@ -601,7 +597,7 @@ test('do not close the server at timeout if a handler is found', async function 
 
   await waitForServer(server)
 
-  http.request({ port: server.address().port, agent: false }).end()
+  http.request({ port: server.address().port }).end()
 })
 
 test('server response timeout', async function (t) {
@@ -618,7 +614,7 @@ test('server response timeout', async function (t) {
 
   await waitForServer(server)
 
-  http.request({ port: server.address().port, agent: false }).end()
+  http.request({ port: server.address().port }).end()
 
   await sub
 

--- a/test.js
+++ b/test.js
@@ -382,7 +382,7 @@ test('server and client do big writes', async function (t) {
   ])
   t.alike(body, expected, 'client response ended')
 
-  server.close()
+  setImmediate(() => server.close())
 })
 
 test('basic protocol negotiation', async function (t) {
@@ -505,8 +505,8 @@ test('custom request headers', async function (t) {
   await waitForServer(server)
 
   server.on('request', (req, res) => {
-    ht.is(req.headers['custom-header'], 'value')
     res.end()
+    ht.is(req.headers['custom-header'], 'value')
   })
 
   const { port } = server.address()
@@ -536,7 +536,7 @@ test('request timeout', async function (t) {
   await sub
 
   serverResponse.end()
-  server.close()
+  setImmediate(() => server.close())
 })
 
 test('server timeout', async function (t) {
@@ -589,7 +589,7 @@ test('do not close the server at timeout if a handler is found', async function 
       t.pass('response timeout')
 
       res.end()
-      server.close()
+      setImmediate(() => server.close())
     })
   })
 
@@ -619,7 +619,7 @@ test('server response timeout', async function (t) {
   await sub
 
   serverResponse.end()
-  server.close()
+  setImmediate(() => server.close())
 })
 
 test('cancel timeouts when has upgrade event handled', async function (t) {

--- a/test.js
+++ b/test.js
@@ -684,18 +684,20 @@ test('socket reuse', async function (t) {
   const firstRequest = http.request({ agent }, (res) => {
     res.on('data', (data) => sub.alike(data, Buffer.from('response')))
 
-    sub.ok(agent._sockets.has(key))
-    sub.is(agent._sockets.get(key).size, 1, `one busy socket at ${key}`)
+    const busySockets = agent._sockets.get(key)
+    sub.ok(busySockets)
+    sub.is(busySockets.size, 1, `one busy socket at ${key}`)
 
-    firstRequestSocket = agent._sockets.get(key).values().next().value
+    firstRequestSocket = busySockets.values().next().value
   }).end()
 
   firstRequest.on('close', () => {
     setImmediate(() => {
       sub.is(agent._sockets.size, 0, 'no busy sockets')
 
-      sub.ok(agent._freeSockets.has(key))
-      sub.is(agent._freeSockets.get(key).length, 1, `one free socket at ${key}`)
+      const freeSockets = agent._freeSockets.get(key)
+      sub.ok(freeSockets)
+      sub.is(freeSockets.size, 1, `one free socket at ${key}`)
 
       triggerSecondRequest()
     })
@@ -705,7 +707,8 @@ test('socket reuse', async function (t) {
     const secondRequest = http.request({ agent }, (res) => {
       res.on('data', (data) => sub.alike(data, Buffer.from('response')))
 
-      secondRequestSocket = agent._sockets.get(key).values().next().value
+      const busySockets = agent._sockets.get(key)
+      secondRequestSocket = busySockets.values().next().value
       sub.ok(firstRequestSocket === secondRequestSocket, 'socket is being reused')
     }).end()
 


### PR DESCRIPTION
Not included on this first draft:

- request pool (maxSockets, maxTotalSockets and maxTotalSockets aren't being used yet)
- 'agentRemove' event
- ~~`agent.reuseSocket` request parameter~~ **added**
- `scheduling` option
- agent timeout support

---

What is included:

- agent.keepSocketAlive
- agent.getName (minimal version)
- socket reuse with `agent.getSocket` and socket 'free' event
- agent.destroy

---

Extra thing: because `http.request` by default uses the global agent, which enables `keepAlive` by default, it made some previous tests start to get stuck, the solution was to add `agent: false` option.