### PR TITLE
Reenable default agent

### DIFF
--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -10,10 +10,7 @@ module.exports = class HTTPClientRequest extends HTTPOutgoingMessage {
 
     opts = opts ? { ...opts } : {}
 
-    // TODO: Renable the default global agent when tests have been sorted
-    // const agent = opts.agent === false ? new HTTPAgent() : opts.agent || HTTPAgent.global
-
-    const agent = opts.agent || new HTTPAgent()
+    const agent = opts.agent === false ? new HTTPAgent() : opts.agent || HTTPAgent.global
     const method = opts.method || 'GET'
     const path = opts.path || '/'
     const host = opts.host = opts.host || 'localhost'

--- a/test.js
+++ b/test.js
@@ -261,7 +261,7 @@ test('chunked', async function (t) {
     })
 
     res.write('response part 1 + ')
-    res.end('response part 2')
+    setImmediate(() => { res.end('response part 2') })
 
     req.on('close', () => t.pass('server request closed'))
     res.on('close', () => t.pass('server response closed'))
@@ -277,7 +277,7 @@ test('chunked', async function (t) {
     path: '/'
   }, (req) => {
     req.write('request body part 1 + ')
-    req.end('request body part 2')
+    setImmediate(() => { req.end('request body part 2') })
   })
 
   t.absent(reply.error)
@@ -348,10 +348,10 @@ test('server and client do big writes', async function (t) {
         Buffer.alloc(2 * 1024 * 1024, 'asdf')
       ])
       t.alike(body, expected, 'request body ended')
-    })
 
-    res.write(Buffer.alloc(2 * 1024 * 1024, 'abcd'))
-    res.end(Buffer.alloc(2 * 1024 * 1024, 'efgh'))
+      res.write(Buffer.alloc(2 * 1024 * 1024, 'abcd'))
+      setImmediate(() => { res.end(Buffer.alloc(2 * 1024 * 1024, 'efgh')) })
+    })
 
     req.on('close', () => t.pass('server request closed'))
     res.on('close', () => t.pass('server response closed'))
@@ -367,7 +367,7 @@ test('server and client do big writes', async function (t) {
     path: '/'
   }, (req) => {
     req.write(Buffer.alloc(2 * 1024 * 1024, 'qwer'))
-    req.end(Buffer.alloc(2 * 1024 * 1024, 'asdf'))
+    setImmediate(() => { req.end(Buffer.alloc(2 * 1024 * 1024, 'asdf')) })
   })
 
   t.is(reply.response.statusCode, 200)

--- a/test.js
+++ b/test.js
@@ -261,7 +261,7 @@ test('chunked', async function (t) {
     })
 
     res.write('response part 1 + ')
-    setImmediate(() => { res.end('response part 2') })
+    res.end('response part 2')
 
     req.on('close', () => t.pass('server request closed'))
     res.on('close', () => t.pass('server response closed'))
@@ -277,7 +277,7 @@ test('chunked', async function (t) {
     path: '/'
   }, (req) => {
     req.write('request body part 1 + ')
-    setImmediate(() => { req.end('request body part 2') })
+    req.end('request body part 2')
   })
 
   t.absent(reply.error)
@@ -351,7 +351,7 @@ test('server and client do big writes', async function (t) {
     })
 
     res.write(Buffer.alloc(2 * 1024 * 1024, 'abcd'))
-    setImmediate(() => { res.end(Buffer.alloc(2 * 1024 * 1024, 'efgh')) })
+    res.end(Buffer.alloc(2 * 1024 * 1024, 'efgh'))
 
     req.on('close', () => t.pass('server request closed'))
     res.on('close', () => t.pass('server response closed'))
@@ -367,7 +367,7 @@ test('server and client do big writes', async function (t) {
     path: '/'
   }, (req) => {
     req.write(Buffer.alloc(2 * 1024 * 1024, 'qwer'))
-    setImmediate(() => { req.end(Buffer.alloc(2 * 1024 * 1024, 'asdf')) })
+    req.end(Buffer.alloc(2 * 1024 * 1024, 'asdf'))
   })
 
   t.is(reply.response.statusCode, 200)


### PR DESCRIPTION
There was a possible deadlock, I noticed that the operation: 
`res.end(Buffer.alloc(2 * 1024 * 1024, 'efgh'))` (server response)
was sometimes being completely read before: 
`res.end(Buffer.alloc(2 * 1024 * 1024, 'asdf'))` (request body).

 Maybe because of the multiple usages of `setImmediate`, the solution was to send the serve response at `request.on('end')`, avoiding the race condition.