### PR TITLE
set error handler to avoid accidental crashes (maybe)

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -138,6 +138,7 @@ class HTTPAgent extends EventEmitter {
       socket = this.createConnection(opts)
 
       socket
+        .on('error', noop) // someone needs to handle it
         .on('free', onfree)
         .on('end', onremove)
         .on('finish', onremove)
@@ -218,3 +219,5 @@ HTTPAgent.global = new HTTPAgent({ keepAlive: 1000, timeout: 5000 })
 module.exports = HTTPAgent
 
 Bare.on('idle', HTTPAgent._onidle.bind(HTTPAgent))
+
+function noop() {}


### PR DESCRIPTION
didnt observe this but seems needed, please scrutinise (any unhandled error event will crash process)